### PR TITLE
Add static_methods function

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,6 @@
 
 Tricks.jl is an experimental package that does tricks with the with Julia edge system.
 
-It is presently unregistered. So install via
-```
-pkg> add https://github.com/oxinabox/Tricks.jl/
-```
-
-
 Currently it has 1 trick:
 `static_hasmethod`.
 This is like `hasmethod` but it does not trigger any dynamic lookup of the method table.
@@ -25,6 +19,7 @@ If methods are added, recompilation is triggered.
 This is based on https://github.com/JuliaLang/julia/pull/32732
 and that thread should be read before use.
 
+**If you can make a reproducable case of `static_hasmethod` not working please post in [#2](https://github.com/oxinabox/Tricks.jl/issues/2)**
 
 ### We can use this to declare traits.
 For demonstration we include versions based on static and nonstatic `has_method`.

--- a/src/Tricks.jl
+++ b/src/Tricks.jl
@@ -1,44 +1,44 @@
 module Tricks
 
-    using Base: rewrap_unionall, unwrap_unionall, uncompressed_ast
-    using Base: CodeInfo
+using Base: rewrap_unionall, unwrap_unionall, uncompressed_ast
+using Base: CodeInfo
 
-    export static_hasmethod
+export static_hasmethod
 
-    # This is used to create the CodeInfo returned by static_hasmethod.
-    _hasmethod_false(@nospecialize(f), @nospecialize(t)) = false
-    _hasmethod_true(@nospecialize(f), @nospecialize(t)) = true
+# This is used to create the CodeInfo returned by static_hasmethod.
+_hasmethod_false(@nospecialize(f), @nospecialize(t)) = false
+_hasmethod_true(@nospecialize(f), @nospecialize(t)) = true
 
-    """
-        static_hasmethod(f, type_tuple::Type{<:Tuple)
+"""
+            static_hasmethod(f, type_tuple::Type{<:Tuple)
 
-    Like `hasmethod` but runs at compile-time (and does not accept a worldage argument).
+        Like `hasmethod` but runs at compile-time (and does not accept a worldage argument).
 
-    !!! Note
-        This absolutely must *not* be called dynamically. Else it will fail to update
-        when new methods are declared.
-        If you do not know how to ensure that it is not called dynamically,
-        do not use this.
-    """
-    @generated function static_hasmethod(@nospecialize(f), @nospecialize(t::Type{T}),) where {T<:Tuple}
-        # The signature type:
-        world = typemax(UInt)
-        method_insts = Core.Compiler.method_instances(f.instance, T, world)
-        method_doesnot_exist = isempty(method_insts)
-        ret_func = method_doesnot_exist ? _hasmethod_false : _hasmethod_true
-        ci_orig = uncompressed_ast(typeof(ret_func).name.mt.defs.func)
-        ci = ccall(:jl_copy_code_info, Ref{CodeInfo}, (Any,), ci_orig)
+        !!! Note
+            This absolutely must *not* be called dynamically. Else it will fail to update
+            when new methods are declared.
+            If you do not know how to ensure that it is not called dynamically,
+            do not use this.
+        """
+@generated function static_hasmethod(@nospecialize(f), @nospecialize(t::Type{T}),) where {T<:Tuple}
+    # The signature type:
+    world = typemax(UInt)
+    method_insts = Core.Compiler.method_instances(f.instance, T, world)
+    method_doesnot_exist = isempty(method_insts)
+    ret_func = method_doesnot_exist ? _hasmethod_false : _hasmethod_true
+    ci_orig = uncompressed_ast(typeof(ret_func).name.mt.defs.func)
+    ci = ccall(:jl_copy_code_info, Ref{CodeInfo}, (Any,), ci_orig)
 
-        # Now we add the edges so if a method is defined this recompiles
-        if method_doesnot_exist
-            # No method so attach to method table
-            mt = f.name.mt
-            typ = rewrap_unionall(Tuple{f, unwrap_unionall(T).parameters...}, T)
-            ci.edges = Core.Compiler.vect(mt, typ)
-        else  # method exists, attach edges to all instances
-            ci.edges = method_insts
-        end
-        return ci
+    # Now we add the edges so if a method is defined this recompiles
+    if method_doesnot_exist
+        # No method so attach to method table
+        mt = f.name.mt
+        typ = rewrap_unionall(Tuple{f, unwrap_unionall(T).parameters...}, T)
+        ci.edges = Core.Compiler.vect(mt, typ)
+    else  # method exists, attach edges to all instances
+        ci.edges = method_insts
     end
+    return ci
+end
 
 end

--- a/src/Tricks.jl
+++ b/src/Tricks.jl
@@ -10,16 +10,16 @@ _hasmethod_false(@nospecialize(f), @nospecialize(t)) = false
 _hasmethod_true(@nospecialize(f), @nospecialize(t)) = true
 
 """
-            static_hasmethod(f, type_tuple::Type{<:Tuple)
+    static_hasmethod(f, type_tuple::Type{<:Tuple)
 
-        Like `hasmethod` but runs at compile-time (and does not accept a worldage argument).
+Like `hasmethod` but runs at compile-time (and does not accept a worldage argument).
 
-        !!! Note
-            This absolutely must *not* be called dynamically. Else it will fail to update
-            when new methods are declared.
-            If you do not know how to ensure that it is not called dynamically,
-            do not use this.
-        """
+!!! Note
+    This absolutely must *not* be called dynamically. Else it will fail to update
+    when new methods are declared.
+    If you do not know how to ensure that it is not called dynamically,
+    do not use this.
+"""
 @generated function static_hasmethod(@nospecialize(f), @nospecialize(t::Type{T}),) where {T<:Tuple}
     # The signature type:
     world = typemax(UInt)
@@ -61,6 +61,18 @@ function expr_to_codeinfo(m, argnames, spnames, sp, e)
     ci = ccall(:jl_expand, Any, (Any, Any), ex, m)
 end
 
+
+"""
+    static_hasmethod(f, type_tuple::Type{<:Tuple)
+
+Like `hasmethod` but runs at compile-time (and does not accept a worldage argument).
+
+!!! Note
+    This absolutely must *not* be called dynamically. Else it will fail to update
+    when new methods are declared.
+    If you do not know how to ensure that it is not called dynamically,
+    do not use this.
+"""
 static_methods(@nospecialize(f)) = _static_methods(Main, f, Tuple{Vararg{Any}})
 static_methods(@nospecialize(f) , @nospecialize(_T::Type)) = _static_methods(Main, f, _T)
 @generated function _static_methods(@nospecialize(m::Module), @nospecialize(f) , @nospecialize(_T::Type{T})) where {T <: Tuple}

--- a/src/Tricks.jl
+++ b/src/Tricks.jl
@@ -42,6 +42,7 @@ Like `hasmethod` but runs at compile-time (and does not accept a worldage argume
 end
 
 
+
 function expr_to_codeinfo(argnames, spnames, sp, e)
     lam = Expr(:lambda, argnames,
                Expr(Symbol("scope-block"),
@@ -83,17 +84,8 @@ static_methods(@nospecialize(f)) = static_methods(f, Tuple{Vararg{Any}})
 
     mt = f.name.mt
     # Now we add the edges so if a method is defined this recompiles
-
-
     mt = f.name.mt
     ci.edges = Core.Compiler.vect(mt, Tuple{Vararg{Any}})
-    # if method_doesnot_exist
-    #     # No method so attach to method table
-    #     mt = f.name.mt
-    #     ci.edges = Core.Compiler.vect(mt, (mt, Tuple{Vararg{Any}}))
-    # else  # method exists, attach edges to all instances
-    #     ci.edges = method_insts
-    # end
     return ci
 end
 

--- a/src/Tricks.jl
+++ b/src/Tricks.jl
@@ -43,14 +43,13 @@ end
 
 
 
-function expr_to_codeinfo(argnames, spnames, sp, e)
+function create_codeinfo_with_returnvalue(argnames, spnames, sp, e)
     lam = Expr(:lambda, argnames,
                Expr(Symbol("scope-block"),
                     Expr(:block,
                         Expr(:return,
-                            Expr(:block,
                                 e,
-                            )))))
+                             ))))
     ex = if spnames === nothing
         lam
     else
@@ -77,12 +76,10 @@ static_methods(@nospecialize(f)) = static_methods(f, Tuple{Vararg{Any}})
     methods(f.instance)
 
     ms = methods(f.instance, T)
-    ci = expr_to_codeinfo([Symbol("#self#"), :f, :_T], [:T], (:T,), :($ms))
+    ci = create_codeinfo_with_returnvalue([Symbol("#self#"), :f, :_T], [:T], (:T,), :($ms))
 
     method_insts = Core.Compiler.method_instances(f.instance, T, world)
-    method_doesnot_exist = isempty(method_insts)
 
-    mt = f.name.mt
     # Now we add the edges so if a method is defined this recompiles
     mt = f.name.mt
     ci.edges = Core.Compiler.vect(mt, Tuple{Vararg{Any}})

--- a/src/Tricks.jl
+++ b/src/Tricks.jl
@@ -87,13 +87,17 @@ static_methods(@nospecialize(f) , @nospecialize(_T::Type)) = _static_methods(Mai
 
     mt = f.name.mt
     # Now we add the edges so if a method is defined this recompiles
-    if method_doesnot_exist
-        # No method so attach to method table
-        mt = f.name.mt
-        ci.edges = Core.Compiler.vect(mt, (mt, Tuple{Vararg{Any}}))
-    else  # method exists, attach edges to all instances
-        ci.edges = method_insts
-    end
+
+
+    mt = f.name.mt
+    ci.edges = Core.Compiler.vect(mt, Tuple{Vararg{Any}})
+    # if method_doesnot_exist
+    #     # No method so attach to method table
+    #     mt = f.name.mt
+    #     ci.edges = Core.Compiler.vect(mt, (mt, Tuple{Vararg{Any}}))
+    # else  # method exists, attach edges to all instances
+    #     ci.edges = method_insts
+    # end
     return ci
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,6 +48,11 @@ struct Foo end
     end
 end
 
+module Bar
+h(::Int) = 1
+
+end
+using .Bar
 
 @testset "static_methods" begin
     f(x) = x + 1
@@ -59,4 +64,8 @@ end
     @test (length ∘ collect ∘ static_methods)(g) == 1
     g(x) = x+1
     @test (length ∘ collect ∘ static_methods)(g) == 2
+
+    @test (length ∘ collect ∘ static_methods)(Bar.h) == 1
+    Bar.h(x) = x
+    @test (length ∘ collect ∘ static_methods)(Bar.h) == 2
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,4 +54,9 @@ end
     @test (length ∘ collect ∘ static_methods)(f) == 1
     f(::Int) = 1
     @test (length ∘ collect ∘ static_methods)(f) == 2
+
+    g(::Int) = 1
+    @test (length ∘ collect ∘ static_methods)(g) == 1
+    g(x) = x+1
+    @test (length ∘ collect ∘ static_methods)(g) == 2
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,3 +47,11 @@ struct Foo end
         @test iterableness_static(Foo) === NonIterable()
     end
 end
+
+
+@testset "static_methods" begin
+    f(x) = x + 1
+    @test (length ∘ collect ∘ static_methods)(f) == 1
+    f(::Int) = 1
+    @test (length ∘ collect ∘ static_methods)(f) == 2
+end


### PR DESCRIPTION
This is the result of some explorations I took in finding all the methods of a function at compile time, with back-edges built in. 
```julia
julia> using Tricks

julia> f(x) = x + 1
f (generic function with 1 method)

julia> static_methods(f)
# 1 method for generic function "f":
[1] f(x) in Main at REPL[2]:1

julia> @btime static_methods(f);
  43.324 ns (0 allocations: 0 bytes)

julia> @btime methods(f);
  2.250 μs (12 allocations: 720 bytes)
```
As you can see it happens at compile time, but also gets recompiled when new methods are added:
```julia
julia> f(::Int) = 1
f (generic function with 2 methods)

julia> static_methods(f)
# 2 methods for generic function "f":
[1] f(::Int64) in Main at REPL[6]:1
[2] f(x) in Main at REPL[2]:1

julia> f(x, y) = x / y
f (generic function with 3 methods)

julia> static_methods(f, Tuple{Int, Float64})
# 1 method for generic function "f":
[1] f(x, y) in Main at REPL[9]:1
```

I messed with the indentation to reflect regular module organization, but if you don't like that I can revert it.