### PR TITLE
check the MethodInstances actually match

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tricks"
 uuid = "410a4b4d-49e4-4fbc-ab6d-cb71b17b3775"
 authors = ["Lyndon White"]
-version = "0.1.1"
+version = "0.1.2"
 
 [compat]
 julia = "1.3"

--- a/src/Tricks.jl
+++ b/src/Tricks.jl
@@ -19,7 +19,7 @@ Like `hasmethod` but runs at compile-time (and does not accept a worldage argume
     world = typemax(UInt)
     method_insts = Core.Compiler.method_instances(f.instance, T, world)
 
-    ftype = Tuple{f, T.parameters...}
+    ftype = Tuple{f, fieldtypes(T)...}
     covering_method_insts = [mi for mi in method_insts if ftype <: mi.def.sig]
 
     method_doesnot_exist = isempty(covering_method_insts)

--- a/src/Tricks.jl
+++ b/src/Tricks.jl
@@ -34,7 +34,7 @@ Like `hasmethod` but runs at compile-time (and does not accept a worldage argume
         typ = rewrap_unionall(Tuple{f, unwrap_unionall(T).parameters...}, T)
         ci.edges = Core.Compiler.vect(mt, typ)
     else  # method exists, attach edges to all instances
-        ci.edges = method_insts
+        ci.edges = covering_method_insts
     end
     return ci
 end

--- a/src/Tricks.jl
+++ b/src/Tricks.jl
@@ -18,7 +18,11 @@ Like `hasmethod` but runs at compile-time (and does not accept a worldage argume
     # The signature type:
     world = typemax(UInt)
     method_insts = Core.Compiler.method_instances(f.instance, T, world)
-    method_doesnot_exist = isempty(method_insts)
+
+    ftype = Tuple{f, T.parameters...}
+    dispatch_able_method_insts = [mi for mi in method_insts if ftype <: mi.def.sig]
+
+    method_doesnot_exist = isempty(dispatch_able_method_insts)
     ret_func = method_doesnot_exist ? _hasmethod_false : _hasmethod_true
     ci_orig = uncompressed_ast(typeof(ret_func).name.mt.defs.func)
     ci = ccall(:jl_copy_code_info, Ref{CodeInfo}, (Any,), ci_orig)

--- a/src/Tricks.jl
+++ b/src/Tricks.jl
@@ -20,9 +20,9 @@ Like `hasmethod` but runs at compile-time (and does not accept a worldage argume
     method_insts = Core.Compiler.method_instances(f.instance, T, world)
 
     ftype = Tuple{f, T.parameters...}
-    dispatch_able_method_insts = [mi for mi in method_insts if ftype <: mi.def.sig]
+    covering_method_insts = [mi for mi in method_insts if ftype <: mi.def.sig]
 
-    method_doesnot_exist = isempty(dispatch_able_method_insts)
+    method_doesnot_exist = isempty(covering_method_insts)
     ret_func = method_doesnot_exist ? _hasmethod_false : _hasmethod_true
     ci_orig = uncompressed_ast(typeof(ret_func).name.mt.defs.func)
     ci = ccall(:jl_copy_code_info, Ref{CodeInfo}, (Any,), ci_orig)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,6 +52,15 @@ has_no_calls(ir) = all(stmt->!Meta.isexpr(stmt, :call), ir)
 
         @test iterableness_static(Foo) === NonIterable()
     end
+
+
+    @testset "abstrct type args" begin
+        # https://github.com/oxinabox/Tricks.jl/issues/14
+
+        goo(x::Integer) = 1
+        @assert !hasmethod(goo, Tuple{Real})  # the behavour we want to match
+        @test !static_hasmethod(goo, Tuple{Real})
+    end
 end
 
 module Bar

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,12 +54,16 @@ has_no_calls(ir) = all(stmt->!Meta.isexpr(stmt, :call), ir)
     end
 
 
-    @testset "abstrct type args" begin
+    @testset "abstract type args" begin
         # https://github.com/oxinabox/Tricks.jl/issues/14
 
         goo(x::Integer) = 1
-        @assert !hasmethod(goo, Tuple{Real})  # the behavour we want to match
+        @assert !hasmethod(goo, Tuple{Real})  # the behaviour we want to match
         @test !static_hasmethod(goo, Tuple{Real})
+
+        goo(x::Number) = 2
+        @assert hasmethod(goo, Tuple{Real})   # Now it _is_ covered.
+        @test static_hasmethod(goo, Tuple{Real})   # Now it _is_ covered.
     end
 end
 


### PR DESCRIPTION
Fixing #14 

Here is the problem that it needs to solve:
```
julia> goo(x::Integer) = 1
goo (generic function with 1 method)

julia> Core.Compiler.method_instances(goo, Tuple{Real})
1-element Array{Core.MethodInstance,1}:
 MethodInstance for goo(::Integer)
```
Which is not something that it can dispatch to in general.
its something it might be able to, or it might not

@nhdaly could I trouble you for a code review?

I am not sure if i need to attatch backedges to all method instances or only those that completely cover the type constraints.
attaching to all will work, but it seems like it is excessive, and so will trigger unnesc recompilations