### PR TITLE
Fix Tricks.jl to work for closures

### DIFF
--- a/src/Tricks.jl
+++ b/src/Tricks.jl
@@ -83,7 +83,7 @@ function _method_table_all_edges_all_methods(f, T)
     # We want to add an edge to _every existing method instance_, so that
     # the deletion of any one of them will trigger recompilation of the function.
     world = typemax(UInt)
-    method_insts = Core.Compiler.method_instances(f.instance, T, world)
+    method_insts = _method_instances(f, T)
     covering_method_insts = method_insts
 
     return vcat(mt_edges, covering_method_insts)
@@ -96,7 +96,7 @@ Returns `length(methods(f, tt))` but runs at compile-time (and does not accept a
 """
 static_method_count(@nospecialize(f)) = static_method_count(f, Tuple{Vararg{Any}})
 @generated function static_method_count(@nospecialize(f) , @nospecialize(_T::Type{T})) where {T <: Tuple}
-    method_count = length(methods(f.instance, T))
+    method_count = length(_methods(f, T))
     ci = create_codeinfo_with_returnvalue([Symbol("#self#"), :f, :_T], [:T], (:T,), :($method_count))
 
     # Now we add the edges so if a method is defined this recompiles

--- a/src/Tricks.jl
+++ b/src/Tricks.jl
@@ -84,6 +84,10 @@ Base.@pure static_fieldtypes(t::Type) = Base.fieldtypes(t)
 Base.@pure static_fieldcount(t::Type) = Base.fieldcount(t)
 
 
+# The below methods are copied and adapted from Julia Base:
+# - https://github.com/JuliaLang/julia/blob/4931faa34a8a1c98b39fb52ed4eb277729120128/base/reflection.jl#L952-L966
+# - https://github.com/JuliaLang/julia/blob/4931faa34a8a1c98b39fb52ed4eb277729120128/base/reflection.jl#L893-L896
+# - https://github.com/JuliaLang/julia/blob/4931faa34a8a1c98b39fb52ed4eb277729120128/base/reflection.jl#L1047-L1055
 # Like Base.methods, but accepts f as a _type_ instead of an instance.
 function _methods(@nospecialize(f_type), @nospecialize(t_type),
                  mod::Union{Tuple{Module},AbstractArray{Module},Nothing}=nothing)

--- a/src/Tricks.jl
+++ b/src/Tricks.jl
@@ -89,21 +89,17 @@ function _methods(@nospecialize(f_type), @nospecialize(t_type),
                  mod::Union{Tuple{Module},AbstractArray{Module},Nothing}=nothing)
     tt = _combine_signature_type(f_type, t_type)
     lim, world = -1, typemax(UInt)
-    ms = Base.Method[
-        m.method
-        for m::Core.MethodMatch in Core.Compiler._methods_by_ftype(tt, lim, world)::Vector
-        if (mod === nothing || m.method.module ∈ mod)
-    ]
+    mft = Core.Compiler._methods_by_ftype(tt, lim, world)
+    ms = Base.Method[m.method for m in mft if (mod === nothing || m.method.module ∈ mod)]
     return Base.MethodList(ms, f_type.name.mt)
 end
 # Like Core.Compiler.method_instances, but accepts f as a _type_ instead of an instance.
 function _method_instances(@nospecialize(f_type), @nospecialize(t_type))
     tt = _combine_signature_type(f_type, t_type)
     lim, world = -1, typemax(UInt)
-    return Core.MethodInstance[
-        Core.Compiler.specialize_method(match)
-        for match in Core.Compiler._methods_by_ftype(tt, lim, world)::Vector
-    ]
+    sm = Core.Compiler.specialize_method
+    mft = Core.Compiler._methods_by_ftype(tt, lim, world)
+    return Core.MethodInstance[sm(match) for match in mft]
 end
 # Like Base.signature_type, but starts with a type for f_type already.
 function _combine_signature_type(@nospecialize(f_type::Type), @nospecialize(args::Type))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -239,6 +239,17 @@ VERSION >= v"1.3" && @testset "closures" begin
                 collect(static_methods(func, Tuple{Int,Int,Int}))
         @test length(static_methods(func, Tuple{Int,Int,Int})) == 0
     end
+
+    @testset "static_method_count" begin
+        @test length(collect(methods(func, Tuple{Int}))) ==
+                static_method_count(func, Tuple{Int}) == 1
+
+        @test length(collect(methods(func, Tuple{}))) ==
+                static_method_count(func, Tuple{}) == 1
+
+        @test length(collect(methods(func, Tuple{Int,Int,Int}))) ==
+                static_method_count(func, Tuple{Int,Int,Int}) == 0
+    end
 end
 
 @testset "static_field____" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -103,6 +103,38 @@ VERSION >= v"1.3" && @testset "static_methods" begin
     @test has_no_calls(code_typed[1].code)
 end
 
+VERSION >= v"1.3" && @testset "closures" begin
+    make_add_n(n) = x->x+n
+    func = make_add_n(2)
+
+    # Add a 0-arg method:
+    (::typeof(func))() = func(0)
+
+    @assert func(1) == 3
+    @assert func() == 2
+
+    @testset "static_hasmethod" begin
+        @assert hasmethod(func, Tuple{Int}) == true
+        @test static_hasmethod(func, Tuple{Int}) == true
+
+        @assert hasmethod(func, Tuple{}) == true
+        @test static_hasmethod(func, Tuple{}) == true
+    end
+
+    @testset "static_methods" begin
+        @test collect(methods(func, Tuple{Int})) ==
+                collect(static_methods(func, Tuple{Int}))
+        @test length(static_methods(func, Tuple{Int})) == 1
+
+        @test collect(methods(func, Tuple{})) ==
+                collect(static_methods(func, Tuple{}))
+        @test length(static_methods(func, Tuple{})) == 1
+
+        @test collect(methods(func, Tuple{Int,Int,Int})) ==
+                collect(static_methods(func, Tuple{Int,Int,Int}))
+        @test length(static_methods(func, Tuple{Int,Int,Int})) == 0
+    end
+end
 
 @testset "static_field____" begin
     function foo(data)


### PR DESCRIPTION
Before this PR, the static functions wouldn't work for closures, because their type doesn't have a singleton `type.instance` defined (since there can be more than one instance!):

```julia
julia> make_add_n(n) = x->x+n
make_add_n (generic function with 1 method)

julia> func = make_add_n(2)
#3 (generic function with 1 method)

julia> typeof(func)
var"#3#4"{Int64}

julia> typeof(func).instance
ERROR: UndefRefError: access to undefined reference
Stacktrace:
 [1] getproperty(x::Type, f::Symbol)
   @ Base ./Base.jl:28
 [2] top-level scope
   @ REPL[13]:1

julia> hasmethod(func, Tuple{Int})
true

julia> static_hasmethod(func, Tuple{Int})
ERROR: UndefRefError: access to undefined reference
Stacktrace:
 [1] getproperty(x::Type, f::Symbol)
   @ Base ./Base.jl:28
 [2] #s1#1
   @ ~/.julia/dev/Tricks/src/Tricks.jl:20 [inlined]
 [3] var"#s1#1"(T::Any, ::Any, f::Any, t::Any)
   @ Tricks ./none:0
 [4] (::Core.GeneratedFunctionStub)(::Any, ::Vararg{Any, N} where N)
   @ Core ./boot.jl:571
 [5] top-level scope
   @ REPL[16]:1
```

After this PR, it works correctly. 😊 

I had to copy some functionality over from Base, because they don't provide easy utility functions that work on function-types, only on function instances, so we had to build that ourselves (since we have only function-types, thanks to the generated function).