### PR TITLE
Support method deletion in `static_methods()` invalidation.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tricks"
 uuid = "410a4b4d-49e4-4fbc-ab6d-cb71b17b3775"
 authors = ["Lyndon White"]
-version = "0.1.4"
+version = "0.1.5"
 
 [compat]
 julia = "1.0"

--- a/src/Tricks.jl
+++ b/src/Tricks.jl
@@ -70,14 +70,14 @@ static_methods(@nospecialize(f)) = static_methods(f, Tuple{Vararg{Any}})
 
     # Now we add the edges so if a method is defined this recompiles
     mt = f.name.mt
+    # We add an edge to the MethodTable itself so that when any new methods
+    # are defined, it recompiles this function.
     mt_edges = Core.Compiler.vect(mt, Tuple{Vararg{Any}})
 
+    # We want to add an edge to _every existing method instance_, so that
+    # the deletion of any one of them will trigger recompilation of this function.
     world = typemax(UInt)
     method_insts = Core.Compiler.method_instances(f.instance, T, world)
-    # TODO: UGH except this actually *doesn't work* with Tuple{Vararg{Any}}.... So currently
-    #       we are over-subscribing to invalidations, but that's better than incorrectness.
-    # ftype = Tuple{f, T.parameters...}
-    # covering_method_insts = [mi for mi in method_insts if ftype <: mi.def.sig]
     covering_method_insts = method_insts
 
     ci.edges = [mt_edges..., covering_method_insts...]

--- a/src/Tricks.jl
+++ b/src/Tricks.jl
@@ -87,7 +87,7 @@ function _method_table_all_edges_all_methods(f, T)
     method_insts = Core.Compiler.method_instances(f.instance, T, world)
     covering_method_insts = method_insts
 
-    return [mt_edges..., covering_method_insts...]
+    return vcat(mt_edges, covering_method_insts)
 end
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -101,6 +101,22 @@ VERSION >= v"1.3" && @testset "static_methods" begin
     code_typed = (@code_typed static_methods(f))
     @test code_typed[2] === Base.MethodList  # return type
     @test has_no_calls(code_typed[1].code)
+
+    @testset "delete method" begin
+        i(::Int) = 1
+        @test (length ∘ collect ∘ static_methods)(i) == 1
+        i(x) = x+1
+        @test (length ∘ collect ∘ static_methods)(i) == 2
+
+        Base.delete_method((first ∘ methods)(i))
+        @test (length ∘ collect ∘ static_methods)(i) == 1
+
+        Base.delete_method((first ∘ methods)(i))
+        @test (length ∘ collect ∘ static_methods)(i) == 0
+
+        i(x) = x+1
+        @test (length ∘ collect ∘ static_methods)(i) == 1
+    end
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -143,6 +143,22 @@ VERSION >= v"1.3" && @testset "static_method_count" begin
     code_typed = (@code_typed static_method_count(f))
     @test code_typed[2] === Int  # return type
     @test has_no_calls(code_typed[1].code)
+
+    @testset "delete method" begin
+        i(::Int) = 1
+        @test static_method_count(i) == 1
+        i(x) = x+1
+        @test static_method_count(i) == 2
+
+        Base.delete_method((first ∘ methods)(i))
+        @test static_method_count(i) == 1
+
+        Base.delete_method((first ∘ methods)(i))
+        @test static_method_count(i) == 0
+
+        i(x) = x+1
+        @test static_method_count(i) == 1
+    end
 end
 
 


### PR DESCRIPTION
Add all matching method instances as backedges to `static_methods()`, so
that deleting a method (which apparently only invalidates functions that
inlined that method), will still invalidate our `static_methods()`
function.

Adds test for method deletion. :)

<s>
Note that there is a problem with detecting covering methods when the
provided type includes Varargs, so we currently oversubscribe to more
MethodInstances than we need to. :/
</s>