### PR TITLE
Don't add an edge to `Tuple` to the method tables

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tricks"
 uuid = "410a4b4d-49e4-4fbc-ab6d-cb71b17b3775"
 authors = ["Frames White"]
-version = "0.1.8"
+version = "0.1.9"
 
 [compat]
 julia = "1.0"

--- a/src/Tricks.jl
+++ b/src/Tricks.jl
@@ -100,7 +100,7 @@ function _method_table_all_edges_all_methods(f, T, world = Base.get_world_counte
 
     # We add an edge to the MethodTable itself so that when any new methods
     # are defined, it recompiles the function.
-    mt_edges = Core.Compiler.vect(mt, Tuple{Vararg{Any}})
+    mt_edges = Core.Compiler.vect(mt, Tuple{f,Vararg{Any}})
 
     # We want to add an edge to _every existing method instance_, so that
     # the deletion of any one of them will trigger recompilation of the function.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -234,44 +234,6 @@ VERSION >= v"1.3" && @testset "static_method_count" begin
         Baz{Float64}(x::Int, y::Int) = Baz(x/y)
         @test static_method_count(Baz{Float64}) == 1
     end
-
-    @testset "Tuple" begin
-        # julia> methods(Base.Tuple)
-        # # 6 methods for type constructor:
-        #  [1] Tuple(index::CartesianIndex)
-        #      @ Base.IteratorsMD multidimensional.jl:103
-        #  [2] Tuple(nt::NamedTuple)
-        #      @ Base namedtuple.jl:197
-        #  [3] Tuple(x::Array{T, 0}) where T
-        #      @ Base tuple.jl:389
-        #  [4] Tuple(x::Ref)
-        #      @ Base tuple.jl:388
-        #  [5] (::Type{T})(x::Tuple) where T<:Tuple
-        #      @ Base tuple.jl:386
-        #  [6] (::Type{T})(itr) where T<:Tuple
-        #      @ Base tuple.jl:391
-        default_method_count = static_method_count(Base.Tuple)
-        Base.Tuple(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q,r,s,t,u,v,w,x,y,z) = 1
-        # julia> methods(Base.Tuple)
-        # # 8 methods for type constructor:
-        #  [1] Tuple(index::CartesianIndex)
-        #      @ Base.IteratorsMD multidimensional.jl:103
-        #  [2] Tuple(x::Array{T, 0}) where T
-        #      @ Base tuple.jl:389
-        #  [3] Tuple(x::Ref)
-        #      @ Base tuple.jl:388
-        #  [4] (::Type{T})(x::Tuple) where T<:Tuple
-        #      @ Base tuple.jl:386
-        #  [5] Tuple(nt::NamedTuple)
-        #      @ Base namedtuple.jl:197
-        #  [6] (::Type{T})(nt::NamedTuple) where T<:Tuple
-        #      @ Base namedtuple.jl:198
-        #  [7] Tuple(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z)
-        #      @ Main REPL[5]:1
-        #  [8] (::Type{T})(itr) where T<:Tuple
-        #      @ Base tuple.jl:391
-        @test static_method_count(Base.Tuple) == default_method_count + 2
-    end
 end
 
 VERSION >= v"1.3" && @testset "closures" begin


### PR DESCRIPTION
We noticed that `Tricks.jl` were adding an edge to `Tuple` which was slowing down our package image generation in the verify edges stage, due to expensive method matching; basically doing this:
```
julia> @time Base._methods_by_ftype(Tuple, 120000, Base.get_world_counter())
1385.862163 seconds (2.49 M allocations: 245.845 MiB, 0.00% gc time)
```
(our sysimage is quite large making the impact of this very pronounced). I believe this is the issue number #7.

`SnoopCompile.@snoopr` reported an invalidation of `Tuple` and pointed to `Tricks.static_method_count`. After playing with this package for a bit I put together this PR which seems to fix the problem for us, but to be honest, I'm not very confident that what I've done is entirely correct and robust.

Locally the tests were passing as did this toy script:

```julia
using Tricks

function foo end
@info Tricks.static_method_count(foo)

foo() = 0
@info Tricks.static_method_count(foo)

foo(x) = 1
@info Tricks.static_method_count(foo)

Base.delete_method(methods(foo)[1])
@info Tricks.static_method_count(foo)

foo(x, y) = 2
@info Tricks.static_method_count(foo)
```
which produced:
```
[ Info: 0
[ Info: 1
[ Info: 2
[ Info: 1
[ Info: 2
```
