### PR TITLE
Add an explicit `invokelatest` after `delete_method` in loop

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -158,10 +158,11 @@ end
 
         while length(collect(methods(j))) > 0
             Base.delete_method((first ∘ methods)(j))
-
-            T = Tuple{Any, Vararg{Any}}
-            @test (length ∘ collect ∘ static_methods)(j, T) == length(collect(methods(j)))
-            @test static_method_count(j, T) == length(collect(methods(j)))
+            invokelatest() do
+                T = Tuple{Any, Vararg{Any}}
+                @test (length ∘ collect ∘ static_methods)(j, T) == length(collect(methods(j)))
+                @test static_method_count(j, T) == length(collect(methods(j)))
+            end
         end
     end
 end


### PR DESCRIPTION
Loops will no longer have implicit world age increments at top level in Julia 1.12. See https://github.com/JuliaLang/julia/pull/56509.