### PR TITLE
Update create_codeinfo_with_returnvalue

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -17,7 +17,8 @@ jobs:
           - "1.3"  # most features work only on 1.3+
           - "1"    # Latest Release
           - "1.11"
-          - "~1.12.0-rc1"
+          - "1.12"
+          - "nightly"
         os:
           - ubuntu-latest
         arch:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Tricks"
 uuid = "410a4b4d-49e4-4fbc-ab6d-cb71b17b3775"
 authors = ["Frames White"]
-version = "0.1.12"
+version = "0.1.13"
 
 [compat]
 julia = "1.0"

--- a/src/Tricks.jl
+++ b/src/Tricks.jl
@@ -59,7 +59,11 @@ function create_codeinfo_with_returnvalue(argnames, spnames, sp, value)
     if spnames !== nothing
         expr = Expr(Symbol("with-static-parameters"), expr, spnames...)
     end
-    ci = ccall(:jl_expand, Any, (Any, Any), expr, @__MODULE__)
+    @static if VERSION >= v"1.13.0-DEV"
+        ci = Meta.lower(@__MODULE__, expr)
+    else
+        ci = ccall(:jl_expand, Any, (Any, Any), expr, @__MODULE__)
+    end
     return ci
 end
 


### PR DESCRIPTION
* Use Meta.lower for Julia 1.13+ as jl_expand no longer exists